### PR TITLE
fixed memory barrier typo in octreebuilder

### DIFF
--- a/src/OctreeBuilder.cpp
+++ b/src/OctreeBuilder.cpp
@@ -105,7 +105,7 @@ void OctreeBuilder::Build(Octree *octree, const Voxelizer &voxelizer, int octree
 		{
 			m_modify_arg_shader.Use();
 			glDispatchCompute(1, 1, 1);
-			glMemoryBarrier(GL_SHADER_STORAGE_BUFFER | GL_COMMAND_BARRIER_BIT);
+			glMemoryBarrier(GL_SHADER_STORAGE_BUFFER_BIT | GL_COMMAND_BARRIER_BIT);
 
 			m_alloc_node_shader.Use();
 			glDispatchComputeIndirect(0);


### PR DESCRIPTION
hey, in octreebuilder cpp, youve used GL_SHADER_STORAGE_BUFFER, meaning probably GL_SHADER_STORAGE_BUFFER_BIT.
this pull request contains a fix for this typo.